### PR TITLE
Instantiate the identity monad.

### DIFF
--- a/src/Data/Flat/Instances.hs
+++ b/src/Data/Flat/Instances.hs
@@ -33,6 +33,7 @@ import           Data.MonoTraversable
 import qualified Data.Sequence         as S
 import           Data.Sequences
 import qualified Data.Text             as T
+import Data.Functor.Identity (Identity)
 import           Prelude               hiding (mempty)
 
 -- Flat instances for common types
@@ -177,6 +178,8 @@ instance Flat a => Flat (S.Seq a) where
   size = sizeSequence
   encode = encodeSequence
   decode = decodeSequence
+
+instance Flat a => Flat (Identity a)
 
 -- |Calculate size of an instance of IsMap
 {-# INLINE sizeMap #-}


### PR DESCRIPTION
This is precondition for serialising any kind of `transformer`.

---

I would also like to make a bunch more standard-datatype instances, including indeed the `transformers` types but also stuff like `UTCTime`. I reckon these should go in a seperate package though, similar to [binary-orphans](https://hackage.haskell.org/package/binary-orphans-0.1.8.0)?