### PR TITLE
Fix test suite duplicate instance.

### DIFF
--- a/flat.cabal
+++ b/flat.cabal
@@ -76,9 +76,9 @@ test-suite flat-test
     build-depends:
                   base >=4.8 && <5
                 , ghc-prim
-                , tasty >= 0.11 && < 0.13
-                , tasty-hunit >= 0.8 && < 0.10
-                , tasty-quickcheck >=0.8.1 && < 0.9.2
+                , tasty >= 0.11 && < 1.1
+                , tasty-hunit >= 0.8 && < 0.11
+                , tasty-quickcheck >=0.8.1 && < 0.11
                 , containers == 0.5.*
                 , deepseq == 1.4.*
                 , quickcheck-instances>=0.3.12 && <0.4
@@ -103,7 +103,7 @@ test-suite flat-doctest
   default-language:   Haskell2010
   type:               exitcode-stdio-1.0
   main-is:            DocSpec.hs
-  build-depends:      base, doctest>=0.11.2 && <0.14,filemanip>=0.3.6.3 && < 0.3.7, flat
+  build-depends:      base, doctest>=0.11.2 && <0.16,filemanip>=0.3.6.3 && < 0.3.7, flat
   HS-Source-Dirs:     test
 
 -- test-suite flat-doctest

--- a/flat.cabal
+++ b/flat.cabal
@@ -57,6 +57,9 @@ library
                   primitive,
                   text,
                   vector
+    if impl(ghc < 8.0)
+      build-depends: semigroups
+
     default-language: Haskell2010
     default-extensions: CPP
     other-extensions: DataKinds DefaultSignatures DeriveAnyClass

--- a/other/EncoderOther/EncoderStrict.hs
+++ b/other/EncoderOther/EncoderStrict.hs
@@ -61,7 +61,8 @@ import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as L
 import           Data.Flat.Pokes
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 
 -- Strict encoder, calculate max length of encoding then alloc single buffer and encode unsafely.
 type Encoding = Writer
@@ -70,6 +71,9 @@ type Encoding = Writer
 newtype Writer = Writer {runWriter::S-> IO S}
 instance Show Writer where show _ = "Writer"
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/PrimCo.hs
+++ b/other/EncoderOther/PrimCo.hs
@@ -10,7 +10,8 @@ import qualified Data.ByteString.Lazy     as L
 import           Data.Flat.Pokes          hiding (eBitsF, eBoolF, eFalseF,
                                            eTrueF, pokeWord)
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -22,6 +23,8 @@ newtype Encoding = Encoding {enc:: E -> IO (Signal Encoding)}
 
 instance Show Encoding where show _ = "Encoding"
 
+instance Semigroup Encoding where
+  (<>) = mappend
 instance Monoid Encoding where
   mempty = Encoding (done . currState)
 

--- a/other/EncoderOther/PrimCont.hs
+++ b/other/EncoderOther/PrimCont.hs
@@ -10,7 +10,8 @@ import           Control.Monad
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -36,6 +37,9 @@ data S = S {nextPtr  :: !(Ptr Word8)
 
 newtype Encoding = Encoding (Step -> Step)
 
+instance Semigroup Encoding where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Encoding where
   {-# INLINE mempty #-}
   mempty = Encoding id -- (\k -> (\s -> k s))

--- a/other/EncoderOther/PrimExc.hs
+++ b/other/EncoderOther/PrimExc.hs
@@ -6,7 +6,8 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),(>=>),wprim,encodersR,me
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -37,6 +38,9 @@ instance Show Writer where show (Writer _) = "Writer"
 data NotEnoughSpaceException = NotEnoughSpaceException S Int [[Writer]] deriving Show
 instance Exception NotEnoughSpaceException
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/PrimLLazy.hs
+++ b/other/EncoderOther/PrimLLazy.hs
@@ -6,7 +6,8 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),(>=>),wprim,encodersR,me
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -41,6 +42,9 @@ data NotEnoughSpaceException = NotEnoughSpaceException S Int [[Writer]] Int deri
 
 instance Exception NotEnoughSpaceException
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/PrimStepStrict.hs
+++ b/other/EncoderOther/PrimStepStrict.hs
@@ -3,12 +3,16 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),encodersR,mempty,bitEnco
 import           Control.Monad
 import qualified Data.ByteString.Lazy as L
 import           Data.Flat.Pokes
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Foldable
 -- Strict encoder, calculate max length of encoding then alloc single buffer and encode unsafely.
 -- Faster than Flat on anything but lN3
 type Encoding = Step
 
+instance Semigroup Step where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Step where
   {-# INLINE mempty #-}
   mempty = Step 0 return

--- a/other/EncoderOther/PrimTag.hs
+++ b/other/EncoderOther/PrimTag.hs
@@ -10,7 +10,8 @@ import           Control.Monad
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -26,6 +27,9 @@ eFalse = eBits 1 0
 
 newtype Encoding = Encoding (Tag -> Tag)
 
+instance Semigroup Encoding where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Encoding where
   {-# INLINE mempty #-}
   mempty = Encoding id

--- a/other/EncoderOther/PrimWriter.hs
+++ b/other/EncoderOther/PrimWriter.hs
@@ -3,7 +3,8 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),encodersR,encodersS,memp
 import           Control.Monad
 import qualified Data.ByteString.Lazy as L
 import           Data.Flat.Pokes
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Foldable
 import Data.Word
 -- Strict encoder, calculate max length of encoding then alloc single buffer and encode unsafely.
@@ -13,6 +14,9 @@ type Encoding = Writer
 newtype Writer = Writer (S-> IO S)
 instance Show Writer where show _ = "Writer"
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/PrimWriterCheck.hs
+++ b/other/EncoderOther/PrimWriterCheck.hs
@@ -5,7 +5,8 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),chkWriter,encodersR,memp
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -49,6 +50,9 @@ encoder e@(E p s) w = catch (runWriter w e >>= (\(E _ s') -> done s')) (\(NotEno
 newtype Writer = Writer {runWriter::E -> IO E}
 instance Show Writer where show (Writer _) = "Writer"
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/PrimWriterRetry.hs
+++ b/other/EncoderOther/PrimWriterRetry.hs
@@ -5,7 +5,8 @@ module Data.Flat.Prim(Encoding,(<>),(<+>),(<|),Step(..),wprim,(>=>),chkWriter,en
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy     as L
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 import           Data.Word
 import           Foreign
 import           Foreign.Ptr
@@ -59,6 +60,9 @@ encoder e@(E p s) w = catch (runWriter w e >>= (\(E _ s') -> done s')) (\(RetryE
 newtype Writer = Writer {runWriter::E -> IO E}
 instance Show Writer where show (Writer _) = "Writer"
 
+instance Semigroup Writer where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Writer where
   {-# INLINE mempty #-}
   mempty = Writer return

--- a/other/EncoderOther/Seq.hs
+++ b/other/EncoderOther/Seq.hs
@@ -3,6 +3,9 @@
 -- Adapted from Data.Sequence.BSeq (sequence package)
 module Data.Seq where
 
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
+
 data Seq a = Empty
            | Leaf !a
            -- | a :<< Seq a
@@ -62,6 +65,9 @@ a <| s = Node (Leaf a) s
 -- viewList Empty               = []
 -- viewList (Node Empty r)      = viewList r
 
+instance Semigroup (Seq a) where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid (Seq a) where
   {-# INLINE mempty #-}
   mempty = Empty

--- a/other/EncoderOther/SeqStd.hs
+++ b/other/EncoderOther/SeqStd.hs
@@ -3,6 +3,9 @@
 -- Adapted from Data.Sequence.BSeq (sequence package)
 module Data.SeqStd where
 
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
+
 infixr 5 <|, :< ,|>
 
 data Seq a = Empty
@@ -72,6 +75,9 @@ viewl (Leaf x)            = x :< Empty
 viewl Empty               = EmptyL
 viewl (Node Empty r)      = viewl r
 
+instance Semigroup (Seq a) where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid (Seq a) where
   {-# INLINE mempty #-}
   mempty = Empty

--- a/src/Data/Flat/Encoder/Strict.hs
+++ b/src/Data/Flat/Encoder/Strict.hs
@@ -12,7 +12,8 @@ import qualified Data.Flat.Encoder.Size       as S
 import           Data.Flat.Encoder.Types
 import           Data.Flat.Types
 import           Data.Foldable
-import           Data.Monoid
+import           Data.Monoid hiding ((<>))
+import           Data.Semigroup
 
 -- |Strict encoder
 strictEncoder :: NumBits -> Encoding -> B.ByteString
@@ -27,6 +28,9 @@ newtype Encoding = Encoding { run :: Prim }
 
 instance Show Encoding where show _ = "Encoding"
 
+instance Semigroup Encoding where
+  {-# INLINE (<>) #-}
+  (<>) = mappend
 instance Monoid Encoding where
   {-# INLINE mempty #-}
   mempty = Encoding return

--- a/test/Test/Data/Arbitrary.hs
+++ b/test/Test/Data/Arbitrary.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE CPP #-}
 -- {-# LANGUAGE TemplateHaskell #-}
+
 module Test.Data.Arbitrary where
 
 -- import qualified Data.ByteString           as B
@@ -13,7 +15,9 @@ import           Test.Tasty.QuickCheck
 
 -- xxx = generate (arbitrary :: Gen (Large (Int)))
 
+#if !MIN_VERSION_quickcheck_instances(0,3,17)
 instance Arbitrary SBS.ShortByteString where arbitrary   = fmap SBS.pack arbitrary
+#endif
 
 
 {-


### PR DESCRIPTION
quickcheck-instances since 0.3.17 [already defines the instance for short ByteStrings](https://github.com/phadej/qc-instances/pull/17), giving
an error when trying to test the library with that version.

Also: fixed some compatibility issues, like missing `Semigroup` instances (which are required in new GHC versions).