### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.stack-work
+stack*.yaml.lock


### PR DESCRIPTION
All contributors will generate a `.stack-work` directory and a `stack.yaml.lock` file. It is standard practice to exclude `.stack-work` directory from version control. `stack.yaml.lock` should not be included in libraries because of [complications to end users](https://github.com/commercialhaskell/stack/issues/4795#issuecomment-488664773). This change makes contributing easier.