### PR TITLE
Don't use the unsafe decodeUtf8

### DIFF
--- a/src/Flat/Decoder/Strict.hs
+++ b/src/Flat/Decoder/Strict.hs
@@ -242,8 +242,10 @@ dUTF16 = do
 dUTF8 :: Get T.Text
 dUTF8 = do
   _ <- dFiller
-  T.decodeUtf8 <$> dByteString_
-
+  bs <- dByteString_
+  case T.decodeUtf8' bs of
+    Right t -> pure t
+    Left e -> fail $ concat ["Input contains invalid UTF-8 data", show e]
 dFiller :: Get ()
 dFiller = do
   tag <- dBool

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,6 +26,7 @@ import qualified Flat.Encoder.Strict as E
 import           Data.Int
 import           Data.Proxy
 import qualified Data.Sequence as Seq
+import           Data.String (fromString)
 import qualified Data.Text as T
 import           Data.Word
 import           Numeric.Natural
@@ -420,6 +421,7 @@ flatTests = testGroup "flat/unflat Unit tests"
       errDec (Proxy :: Proxy Bool) [] -- no data
     , errDec (Proxy :: Proxy Bool) [128] -- no filler
     , errDec (Proxy :: Proxy Bool) [128 + 1, 1, 2, 4, 8] -- additional bytes
+    , errDec (Proxy :: Proxy Text) (B.unpack (flat ((fromString "\x80") :: B.ByteString))) -- invalid UTF-8
     , encRaw () []
     , encRaw ((), (), Unit) []
     , encRaw (Unit, 'a', Unit, 'a', Unit, 'a', Unit) [97, 97, 97]


### PR DESCRIPTION
`decodeUtf8` throws an exception if the input data is invalid.
Use the version which returns an `Either` so we can fail properly.